### PR TITLE
refactor linting tasks

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -1,7 +1,3 @@
-files:
-  include: 'app/**/*.s+(a|c)ss'
-  ignore:
-    - 'app/theme/vendor/**/*.*'
 options:
   formatter: stylish
   # Merge default rules - override defaults with those specified in this config
@@ -31,6 +27,7 @@ rules:
   mixins-before-declarations: 0
   nesting-depth: 0
   no-color-literals: 0
+  no-empty-rulesets: 2
   no-extends: 2
   no-ids: 2
   no-important: 2

--- a/app/containers/app/app.container.scss
+++ b/app/containers/app/app.container.scss
@@ -1,4 +1,0 @@
-.app {
-  // this comment is here to satisfy sass-lint
-  // it does not allow empty blocks.
-}

--- a/app/theme/vendor/readme.txt
+++ b/app/theme/vendor/readme.txt
@@ -1,2 +1,0 @@
-// any vendor styles should go in this directory
-// sass-lint ignores everything here

--- a/package.json
+++ b/package.json
@@ -9,16 +9,17 @@
     "clean": "npm run clean:build && npm run clean:node_modules",
     "reinstall": "npm run clean && npm install",
     "start": "./node_modules/.bin/nodemon --exec NODE_ENV=development ./node_modules/.bin/babel-node ./server/index.js",
-    "lint": "eslint .",
-    "sass-lint": "sass-lint -c ./.sass-lint.yml './app/**/*.scss' -v -q -i './app/theme/vendor/**/*.scss'",
+    "lint:sass-lint": "sass-lint -c ./.sass-lint.yml './app/**/*.scss' -v",
+    "lint:eslint": "eslint .",
+    "lint": "npm run lint:sass-lint && npm run lint:eslint",
     "build:client": "NODE_ENV=production webpack --config ./webpack.config.js --progress --profile --colors",
     "build:server": "./node_modules/.bin/babel -d ./build ./server -s",
-    "build": "npm run lint && npm run sass-lint && npm run clean:build && npm run build:server && npm run build:client",
+    "build": "npm run lint && npm run clean:build && npm run build:server && npm run build:client",
     "production-build": "npm run build && npm run clean:node_modules && npm install --production",
     "production": "NODE_ENV=production node ./build/index.js",
     "test:mocha": "NODE_ENV=test ./node_modules/.bin/mocha --compilers js:babel-core/register --recursive test/**",
     "test:watch": "NODE_ENV=test ./node_modules/.bin/mocha --compilers js:babel-core/register --recursive --watch test/**",
-    "test": "npm run lint && npm run sass-lint && npm run test:mocha"
+    "test": "npm run lint && npm run test:mocha"
   },
   "dependencies": {
     "async": "1.5.2",


### PR DESCRIPTION
subtasks for lint to dry it up.
remove stubbed directories that serve no current purpose
no-empty-rulesets is now an error
remove empty styles in app.container.scss boilerplate
