### PR TITLE
add public path to production output

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -107,6 +107,7 @@ function getOutput() {
   if (IS_PRODUCTION) {
     output = {
       path: assetsPath,
+      publicPath,
       filename: '[name]-[hash].min.js',
     };
   } else {


### PR DESCRIPTION
production will break without this, it ensures that our assets have an appropriate path.
